### PR TITLE
Angry penguin pl patch 3

### DIFF
--- a/.abf.yml
+++ b/.abf.yml
@@ -1,3 +1,3 @@
 sources:
-  "elisa-0.1.tar.xz": 470b2351441a9256f05776a0a57a04d272b0b0ad
-  "elisa_ru.tar.gz": af9c55dcb68ec9b3459b90de8791707e8f0a672d
+  "elisa-0.0.81.tar.gz": 1c898d2e54220fc7f42038afdc958aa100222620
+  "elisa-0.0.81_ru.tar.gz": ba7c1cf6fadaac6ce066560fda3a3639042cfbe1

--- a/elisa.spec
+++ b/elisa.spec
@@ -57,9 +57,6 @@ A powerful media player for Plasma.
 
 %prep
 %setup -q
-# Disabled patch0 and patch1
-# %patch0 -p1
-# %patch1 -p1
 
 # Russian locale
 pushd po

--- a/elisa.spec
+++ b/elisa.spec
@@ -7,7 +7,8 @@ Group:		Sound
 Url:		https://github.com/KDE/elisa
 Source0:	elisa-0.0.81.tar.gz
 Source1:	elisa-0.0.81_ru.tar.gz
-Patch0:		elisa-desktop.patch
+# Disabled p0 fixed by upstream
+#Patch0:		elisa-desktop.patch
 Patch1:		elisa-0.0.1-cmake.patch
 BuildRequires:	cmake(ECM)
 BuildRequires:	cmake(KF5Archive)
@@ -55,7 +56,8 @@ A powerful media player for Plasma.
 
 %prep
 %setup -q
-%patch0 -p1
+# Disabled patch0
+#%patch0 -p1
 %patch1 -p1
 
 # Russian locale

--- a/elisa.spec
+++ b/elisa.spec
@@ -39,6 +39,7 @@ BuildRequires:	pkgconfig(Qt5Test)
 BuildRequires:	pkgconfig(Qt5WebSockets)
 BuildRequires:	pkgconfig(Qt5Widgets)
 BuildRequires:	pkgconfig(Qt5X11Extras)
+BuildRequires:	pkgconfig(Qt5QuickTest)
 Requires:	qt5-qtquickcontrols2
 
 %description

--- a/elisa.spec
+++ b/elisa.spec
@@ -1,6 +1,6 @@
 Summary:	A powerful media player for Plasma
 Name:		elisa
-Version:	0.81
+Version:	0.0.81
 Release:	1
 License:	LGPLv2+
 Group:		Sound

--- a/elisa.spec
+++ b/elisa.spec
@@ -51,6 +51,7 @@ A powerful media player for Plasma.
 %{_datadir}/kservices5//kcm_elisa_local_file.desktop
 %{_datadir}/kpackage/kcms/kcm_elisa_local_file/
 %{_iconsdir}/hicolor/scalable/apps/elisa.svg
+%{_iconsdir}/hicolor/*/apps/elisa.png
 %{_datadir}/metainfo/org.kde.elisa.appdata.xml
 %{_qt5_plugindir}/kcms/kcm_elisa_local_file.so
 

--- a/elisa.spec
+++ b/elisa.spec
@@ -6,7 +6,7 @@ License:	LGPLv2+
 Group:		Sound
 Url:		https://github.com/KDE/elisa
 Source0:	elisa-0.0.81.tar.gz
-Source1:	elisa-0.0.81_ru.tar.gz
+# Source1:	elisa-0.0.81_ru.tar.gz
 # Disabled Patch0 fixed by upstream
 # Patch0:		elisa-desktop.patch
 # Disabled Patch1 fided by upstream?
@@ -57,11 +57,6 @@ A powerful media player for Plasma.
 
 %prep
 %setup -q
-
-# Russian locale
-pushd po
-tar -xvzf %{SOURCE1}
-popd
 
 %cmake_kde5
 

--- a/elisa.spec
+++ b/elisa.spec
@@ -7,9 +7,10 @@ Group:		Sound
 Url:		https://github.com/KDE/elisa
 Source0:	elisa-0.0.81.tar.gz
 Source1:	elisa-0.0.81_ru.tar.gz
-# Disabled p0 fixed by upstream
-#Patch0:		elisa-desktop.patch
-Patch1:		elisa-0.0.1-cmake.patch
+# Disabled Patch0 fixed by upstream
+# Patch0:		elisa-desktop.patch
+# Disabled Patch1 fided by upstream?
+# Patch1:		elisa-0.0.1-cmake.patch
 BuildRequires:	cmake(ECM)
 BuildRequires:	cmake(KF5Archive)
 BuildRequires:	cmake(KF5ConfigWidgets)
@@ -56,9 +57,9 @@ A powerful media player for Plasma.
 
 %prep
 %setup -q
-# Disabled patch0
-#%patch0 -p1
-%patch1 -p1
+# Disabled patch0 and patch1
+# %patch0 -p1
+# %patch1 -p1
 
 # Russian locale
 pushd po

--- a/elisa.spec
+++ b/elisa.spec
@@ -69,4 +69,3 @@ A powerful media player for Plasma.
 %ninja_install -C build
 
 %find_lang %{name} kcm_elisa_local_file %{name}.lang --with-kde --with-html
-

--- a/elisa.spec
+++ b/elisa.spec
@@ -6,7 +6,7 @@ License:	LGPLv2+
 Group:		Sound
 Url:		https://github.com/KDE/elisa
 Source0:	elisa-0.0.81.tar.gz
-Source1:	elisa_ru.tar.gz
+Source1:	elisa-0.0.81_ru.tar.gz
 Patch0:		elisa-desktop.patch
 Patch1:		elisa-0.0.1-cmake.patch
 BuildRequires:	cmake(ECM)

--- a/elisa.spec
+++ b/elisa.spec
@@ -1,11 +1,11 @@
 Summary:	A powerful media player for Plasma
 Name:		elisa
-Version:	0.1
+Version:	0.81
 Release:	1
 License:	LGPLv2+
 Group:		Sound
 Url:		https://github.com/KDE/elisa
-Source0:	elisa-0.1.tar.xz
+Source0:	elisa-0.0.81.tar.gz
 Source1:	elisa_ru.tar.gz
 Patch0:		elisa-desktop.patch
 Patch1:		elisa-0.0.1-cmake.patch


### PR DESCRIPTION
Build only for cooker because = Qt5 (required version >= 5.9.0)
OMV3 up to Qt5 5.8