### PR TITLE
Drop vlc support, reverts to QtMultimedia

### DIFF
--- a/elisa.spec
+++ b/elisa.spec
@@ -7,7 +7,7 @@
 Summary:	A powerful media player for Plasma
 Name:		elisa
 Version:	25.08.0
-Release:	%{?git:0.%{git}.}1
+Release:	%{?git:0.%{git}.}2
 License:	LGPLv2+
 Group:		Sound
 Url:		https://community.kde.org/Elisa
@@ -35,7 +35,6 @@ BuildRequires:	cmake(KF6KIO)
 BuildRequires:	cmake(KF6IconThemes)
 BuildRequires:	cmake(KF6QQC2DesktopStyle)
 BuildRequires:	pkgconfig(gl)
-BuildRequires:  pkgconfig(libvlc)
 BuildRequires:	pkgconfig(Qt6Core)
 BuildRequires:	pkgconfig(Qt6DBus)
 BuildRequires:	pkgconfig(Qt6Gui)
@@ -51,10 +50,6 @@ BuildRequires:	pkgconfig(Qt6Test)
 BuildRequires:	pkgconfig(Qt6QuickTest)
 BuildRequires:	pkgconfig(Qt6WebSockets)
 BuildRequires:	pkgconfig(Qt6Widgets)
-# libvlc5 is not pulled at installation time and if user remove VLC, then Elisa is completly broken. So let's force it (angry)
-# https://forum.openmandriva.org/t/elisa-crash-on-rock/3700/16
-Requires: %{_lib}vlc5
-Requires: vlc-plugin-pulse
 
 %rename %{_lib}%{name}0
 %rename plasma6-elisa
@@ -74,7 +69,4 @@ A powerful media player for Plasma.
 %{_iconsdir}/hicolor/scalable/apps/elisa.svg
 %{_iconsdir}/hicolor/*/apps/elisa.png
 %{_datadir}/metainfo/org.kde.elisa.appdata.xml
-#{_libdir}/qt6/qml/org/kde/elisa/libelisaqmlplugin.so
-#{_libdir}/qt6/qml/org/kde/elisa/qmldir
-#{_libdir}/qt6/qml/org/kde/elisa/plugins.qmltypes
 %{_datadir}/dbus-1/services/org.kde.elisa.service


### PR DESCRIPTION
Remove `vlc` as a `BuildRequires:` which reverts the build to use `QtMultimedia`.